### PR TITLE
Fix build on windows

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ cargo_toml = "0.10.0"
 futures = "0.3.12"
 notify = "4.0.17"
 html_parser = "0.6.2"
-tui = { version = "0.16.0", features = ["crossterm"] }
+tui = { version = "0.16.0", default-features = false, features = ["crossterm"] }
 crossterm = "0.22.1"
 binary-install = "0.0.2"
 convert_case = "0.5.0"


### PR DESCRIPTION
Not disabling default features brings in `termion` which causes a build failure