### PR TITLE
Refactor extension, make it easy to maintain and unique to register

### DIFF
--- a/extension/LICENSE.txt
+++ b/extension/LICENSE.txt
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2021 DioxusLabs
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/extension/package.json
+++ b/extension/package.json
@@ -17,19 +17,19 @@
         "Other"
     ],
     "activationEvents": [
-        "onCommand:extension.htmlToRsx",
-        "onCommand:extension.htmlToComponent"
+        "onCommand:extension.htmlToDioxusRsx",
+        "onCommand:extension.htmlToDioxusComponent"
     ],
     "main": "./out/extension",
     "contributes": {
         "commands": [
             {
-                "command": "extension.htmlToRsx",
-                "title": "Convert HTML to RSX"
+                "command": "extension.htmlToDioxusRsx",
+                "title": "Dioxus: Convert HTML to RSX"
             },
             {
-                "command": "extension.htmlToComponent",
-                "title": "Convert HTML to Dioxus Component"
+                "command": "extension.htmlToDioxusComponent",
+                "title": "Dioxus: Convert HTML to Component"
             }
         ]
     },
@@ -37,7 +37,8 @@
         "vscode:prepublish": "npm run compile",
         "compile": "tsc -p ./",
         "lint": "eslint . --ext .ts,.tsx",
-        "watch": "tsc -watch -p ./"
+        "watch": "tsc -watch -p ./",
+        "package": "vsce package"
     },
     "devDependencies": {
         "@types/node": "^12.12.0",


### PR DESCRIPTION
1. Refactored extension.ts, merge two functions to one, make it easy to maintain, and added hint to help beginner users
2. Renamed command name, make it unique to the vscode universe.
3. Added LIENSE.txt to prevent warning of vsce every time.