### PR TITLE
A hint to update cargo-generate

### DIFF
--- a/src/cli/create/mod.rs
+++ b/src/cli/create/mod.rs
@@ -59,7 +59,7 @@ impl Create {
             .output()?;
 
         if !generate_output.status.success() {
-            return custom_error!("Generate project failed.");
+            return custom_error!("Generate project failed. Try to update cargo-generate.");
         }
 
         let mut dioxus_file = File::open(project_path.join("Dioxus.toml"))?;


### PR DESCRIPTION
I got an unclear error during the creation process:
```
~/lab$ dioxus create hi-dioxus --template gh:dioxuslabs/dioxus-template
[INFO] 🔧 Start to create a new project 'hi-dioxus'.
Error: ⛔   Git Error: unexpected http status code: 400; class=Http (34)
[ERROR] create error: Generate project failed.
```

The cause happened to be an old version of `cargo-generate` (v0.11.1). After updating to the last release (v0.13.0) the error is gone, so I've added this hint.