### PR TITLE
Remove axum warnings

### DIFF
--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -3,7 +3,7 @@ use axum::{
     http::StatusCode,
     response::IntoResponse,
     routing::{get, get_service},
-    AddExtensionLayer, Router,
+    Router,
 };
 use notify::{RecommendedWatcher, Watcher};
 
@@ -88,7 +88,7 @@ pub async fn startup(config: CrateConfig) -> Result<()> {
                         },
                     ),
                 )
-                .layer(AddExtensionLayer::new(ws_reload_state))
+                .layer(Extension(ws_reload_state))
                 .into_make_service(),
         )
         .await?;


### PR DESCRIPTION
It removes these bulid time warnings:
```
warning: use of deprecated struct `axum::AddExtensionLayer`: Use `axum::extract::Extension` instead. It implements `tower::Layer`
 --> src/server/mod.rs:6:5
  |
6 |     AddExtensionLayer, Router,
  |     ^^^^^^^^^^^^^^^^^
  |
  = note: `#[warn(deprecated)]` on by default

warning: use of deprecated struct `axum::AddExtensionLayer`: Use `axum::extract::Extension` instead. It implements `tower::Layer`
  --> src/server/mod.rs:91:24
   |
91 |                 .layer(AddExtensionLayer::new(ws_reload_state))
   |                        ^^^^^^^^^^^^^^^^^

warning: `dioxus-cli` (lib) generated 2 warnings
    Finished dev [unoptimized + debuginfo] target(s) in 0.09s
```