### PR TITLE
Fix buliding with redefined cargo target dir

### DIFF
--- a/src/cargo.rs
+++ b/src/cargo.rs
@@ -10,6 +10,12 @@ use std::{
 /// How many parent folders are searched for a `Cargo.toml`
 const MAX_ANCESTORS: u32 = 10;
 
+/// Some fields parsed from `cargo metadata` command
+pub struct Metadata {
+    pub workspace_root: PathBuf,
+    pub target_directory: PathBuf,
+}
+
 /// Returns the root of the crate that the command is run from
 ///
 /// If the command is run from the workspace root, this will return the top-level Cargo.toml
@@ -31,37 +37,6 @@ pub fn crate_root() -> Result<PathBuf> {
         .ok_or_else(|| Error::CargoError("Failed to find the cargo directory".to_string()))
 }
 
-/// Returns the root of a workspace
-/// TODO @Jon, find a different way that doesn't rely on the cargo metadata command (it's slow)
-pub fn workspace_root() -> Result<PathBuf> {
-    let output = Command::new("cargo")
-        .args(&["metadata"])
-        .output()
-        .map_err(|_| Error::CargoError("Manifset".to_string()))?;
-
-    if !output.status.success() {
-        let mut msg = str::from_utf8(&output.stderr).unwrap().trim();
-        if msg.starts_with("error: ") {
-            msg = &msg[7..];
-        }
-
-        return Err(Error::CargoError(msg.to_string()));
-    }
-
-    let stdout = str::from_utf8(&output.stdout).unwrap();
-    if let Some(line) = stdout.lines().next() {
-        let meta: serde_json::Value = serde_json::from_str(line)
-            .map_err(|_| Error::CargoError("InvalidOutput".to_string()))?;
-
-        let root = meta["workspace_root"]
-            .as_str()
-            .ok_or_else(|| Error::CargoError("InvalidOutput".to_string()))?;
-        return Ok(root.into());
-    }
-
-    Err(Error::CargoError("InvalidOutput".to_string()))
-}
-
 /// Checks if the directory contains `Cargo.toml`
 fn contains_manifest(path: &Path) -> bool {
     fs::read_dir(path)
@@ -71,4 +46,47 @@ fn contains_manifest(path: &Path) -> bool {
                 .any(|ent| &ent.file_name() == "Cargo.toml")
         })
         .unwrap_or(false)
+}
+
+impl Metadata {
+    /// Returns the struct filled from `cargo metadata` output
+    /// TODO @Jon, find a different way that doesn't rely on the cargo metadata command (it's slow)
+    pub fn get() -> Result<Self> {
+        let output = Command::new("cargo")
+            .args(&["metadata"])
+            .output()
+            .map_err(|_| Error::CargoError("Manifset".to_string()))?;
+
+        if !output.status.success() {
+            let mut msg = str::from_utf8(&output.stderr).unwrap().trim();
+            if msg.starts_with("error: ") {
+                msg = &msg[7..];
+            }
+
+            return Err(Error::CargoError(msg.to_string()));
+        }
+
+        let stdout = str::from_utf8(&output.stdout).unwrap();
+        if let Some(line) = stdout.lines().next() {
+            let meta: serde_json::Value = serde_json::from_str(line)
+                .map_err(|_| Error::CargoError("InvalidOutput".to_string()))?;
+
+            let workspace_root = meta["workspace_root"]
+                .as_str()
+                .ok_or_else(|| Error::CargoError("InvalidOutput".to_string()))?
+                .into();
+
+            let target_directory = meta["target_directory"]
+                .as_str()
+                .ok_or_else(|| Error::CargoError("InvalidOutput".to_string()))?
+                .into();
+
+            return Ok(Self {
+                workspace_root,
+                target_directory,
+            });
+        }
+
+        Err(Error::CargoError("InvalidOutput".to_string()))
+    }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -120,8 +120,9 @@ impl CrateConfig {
         let dioxus_config = DioxusConfig::load()?;
 
         let crate_dir = crate::cargo::crate_root()?;
-        let workspace_dir = crate::cargo::workspace_root()?;
-        let target_dir = workspace_dir.join("target");
+        let meta = crate::cargo::Metadata::get()?;
+        let workspace_dir = meta.workspace_root;
+        let target_dir = meta.target_directory;
 
         let out_dir = match dioxus_config.application.out_dir {
             Some(ref v) => crate_dir.join(v),


### PR DESCRIPTION
With having cargo target folder globally redefined in `~/.cargo/config`, I had a error while running `dioxus serve`:
```
thread 'main' panicked at 'called `Result::unwrap()` on an `Err` value: failed to read `/data/0/lab/hi-dioxus/target/wasm32-unknown-unknown/debug/hi-dioxus.wasm`

Caused by:
    0: failed to read `/data/0/lab/hi-dioxus/target/wasm32-unknown-unknown/debug/hi-dioxus.wasm`
    1: No such file or directory (os error 2)', /home/imbolc/.cargo/registry/src/github.com-1ecc6299db9ec823/dioxus-cli-0.1.4/src/builder.rs:92:40
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
[ERROR] Bindgen build failed! 
This is probably due to the Bindgen version, dioxus-cli using `0.2.79` Bindgen crate.
[ERROR] serve error: I/O Error: No such file or directory (os error 2)
```