### PR TITLE
Service index.html on 404 (for SPA)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,8 @@ hyper = "0.14.17"
 axum = { version = "0.4.5", features = ["ws", "headers"] }
 tower-http = { version = "0.2.2", features = ["fs", "trace"] }
 headers = "0.3.7"
+tower = "0.4.12"
+
 # hyper = { version = "0.14.11", features = ["full"] }
 
 [[bin]]

--- a/src/config.rs
+++ b/src/config.rs
@@ -42,6 +42,7 @@ impl Default for DioxusConfig {
                 watcher: WebWatcherConfing {
                     watch_path: Some(vec![PathBuf::from("src")]),
                     reload_html: Some(false),
+                    index_on_404: Some(false),
                 },
                 resource: WebResourceConfing {
                     dev: WebDevResourceConfing {
@@ -80,6 +81,7 @@ pub struct WebAppConfing {
 pub struct WebWatcherConfing {
     pub watch_path: Option<Vec<PathBuf>>,
     pub reload_html: Option<bool>,
+    pub index_on_404: Option<bool>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]


### PR DESCRIPTION
This was a bit challenging specifically due to the asset dir also being the root dir.  Otherwise one could simply `nest` into asset, then `fallback` to a `ServeFile`.