### PR TITLE
fix path separator for hot reloading

### DIFF
--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -121,6 +121,7 @@ pub async fn startup_hot_reload(config: CrateConfig) -> Result<()> {
                                         log::info!("reloading rsx");
                                         for (old, new) in changed.into_iter() {
                                             let hr = get_location(
+                                                &crate_dir,
                                                 &path.to_path_buf(),
                                                 old.to_token_stream(),
                                             );


### PR DESCRIPTION
pending https://github.com/DioxusLabs/dioxus/pull/462
Changes the path separator to not depend on the build target.