### PR TITLE
Return non-zero exit code on error

### DIFF
--- a/src/cli/build/mod.rs
+++ b/src/cli/build/mod.rs
@@ -40,7 +40,7 @@ impl Build {
                 crate::builder::build_desktop(&crate_config, false)?;
             }
             _ => {
-                return custom_error!("Unsoppurt platform target.");
+                return custom_error!("Unsupported platform target.");
             }
         }
 

--- a/src/cli/clean/mod.rs
+++ b/src/cli/clean/mod.rs
@@ -16,8 +16,7 @@ impl Clean {
             .output()?;
 
         if !output.status.success() {
-            log::error!("Cargo clean failed.");
-            return Ok(());
+            return custom_error!("Cargo clean failed.");
         }
 
         let out_dir = crate_config

--- a/src/cli/create/mod.rs
+++ b/src/cli/create/mod.rs
@@ -17,8 +17,7 @@ pub struct Create {
 impl Create {
     pub fn create(self) -> Result<()> {
         if Self::name_vaild_check(self.name.clone()) {
-            log::error!("❗Unsupported project name.");
-            return Ok(());
+            return custom_error!("❗Unsupported project name.");
         }
 
         let project_path = PathBuf::from(&self.name);

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -22,7 +22,7 @@ use std::{
     fs::{remove_dir_all, File},
     io::{Read, Write},
     path::PathBuf,
-    process::{exit, Command, Stdio},
+    process::{Command, Stdio},
 };
 
 /// Build, bundle, & ship your Dioxus app.

--- a/src/cli/tool/mod.rs
+++ b/src/cli/tool/mod.rs
@@ -30,15 +30,14 @@ impl Tool {
                 if let Some(v) = tools::tools_path().to_str() {
                     println!("{}", v);
                 } else {
-                    log::error!("Tools path get failed.");
+                    return custom_error!("Tools path get failed.");
                 }
             }
             Tool::Add { name } => {
                 let tool_list = tools::tool_list();
 
                 if !tool_list.contains(&name.as_str()) {
-                    log::error!("Tool {name} not found.");
-                    return Ok(());
+                    return custom_error!("Tool {name} not found.");
                 }
                 let target_tool = tools::Tool::from_str(&name).unwrap();
 
@@ -49,17 +48,15 @@ impl Tool {
 
                 log::info!("Start to download tool package...");
                 if let Err(e) = target_tool.download_package().await {
-                    log::error!("Tool download failed: {e}");
-                    return Ok(());
+                    return custom_error!("Tool download failed: {e}");
                 }
 
                 log::info!("Start to install tool package...");
                 if let Err(e) = target_tool.install_package().await {
-                    log::error!("Tool install failed: {e}");
-                    return Ok(());
+                    return custom_error!("Tool install failed: {e}");
                 }
 
-                log::info!("Tool {name} install successfully!");
+                log::info!("Tool {name} installed successfully!");
             }
         }
         Ok(())

--- a/src/cli/translate/mod.rs
+++ b/src/cli/translate/mod.rs
@@ -27,14 +27,11 @@ impl Translate {
         } = self;
 
         let contents = match file {
-            Some(input) => std::fs::read_to_string(&input).unwrap_or_else(|e| {
-                log::error!("Cloud not read input file: {}.", e);
-                exit(0);
-            }),
+            Some(input) => std::fs::read_to_string(&input)
+                .map_err(|e| Error::CustomError(format!("Could not read input file: {e}.")))?,
             None => {
                 if atty::is(atty::Stream::Stdin) {
-                    log::error!("No input file, source, or stdin to translate from.");
-                    exit(0);
+                    return custom_error!("No input file, source, or stdin to translate from.");
                 }
 
                 let mut buffer = String::new();

--- a/src/error.rs
+++ b/src/error.rs
@@ -63,7 +63,7 @@ impl From<hyper::Error> for Error {
 #[macro_export]
 macro_rules! custom_error {
     ($msg:literal $(,)?) => {
-        Err(Error::CustomError($msg.to_string()))
+        Err(Error::CustomError(format!($msg)))
     };
     ($err:expr $(,)?) => {
         Err(Error::from($err))

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,6 @@
 use clap::Parser;
 use dioxus_cli::*;
+use std::process::exit;
 
 #[tokio::main]
 async fn main() -> Result<()> {
@@ -10,42 +11,49 @@ async fn main() -> Result<()> {
         Commands::Translate(opts) => {
             if let Err(e) = opts.translate() {
                 log::error!("🚫 Translate failed: {}", e);
+                exit(1);
             }
         }
 
         Commands::Build(opts) => {
             if let Err(e) = opts.build() {
                 log::error!("🚫 Build project failed: {}", e);
+                exit(1);
             }
         }
 
         Commands::Clean(opts) => {
             if let Err(e) = opts.clean() {
                 log::error!("🚫 Clean project failed: {}", e);
+                exit(1);
             }
         }
 
         Commands::Serve(opts) => {
             if let Err(e) = opts.serve().await {
                 log::error!("🚫 Serve startup failed: {}", e);
+                exit(1);
             }
         }
 
         Commands::Create(opts) => {
             if let Err(e) = opts.create() {
                 log::error!("🚫 Create project failed: {}", e);
+                exit(1);
             }
         }
 
         Commands::Config(opts) => {
             if let Err(e) = opts.config() {
                 log::error!("config error: {}", e);
+                exit(1);
             }
         }
 
         Commands::Tool(opts) => {
             if let Err(e) = opts.tool().await {
                 log::error!("tool error: {}", e);
+                exit(1);
             }
         }
     }


### PR DESCRIPTION
This helps, for example, catching errors returned by dioxus-cli when used in a CI script or other build process.