### PR TITLE
Fix problems on windows and jetbrains

### DIFF
--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -419,19 +419,17 @@ pub struct PrettierOptions {
 }
 
 fn print_console_info(port: u16, config: &CrateConfig, options: PrettierOptions) {
-    print!(
-        "{}",
-        String::from_utf8_lossy(
-            &Command::new(if cfg!(target_os = "windows") {
-                "cls"
-            } else {
-                "clear"
-            })
-            .output()
-            .unwrap()
-            .stdout
-        )
-    );
+    if let Ok(native_clearseq) = Command::new(if cfg!(target_os = "windows") {
+        "cls"
+    } else {
+        "clear"
+    })
+    .output() {
+        print!("{}", String::from_utf8_lossy(&native_clearseq.stdout));
+    } else {
+        // Try ANSI-Escape characters
+        print!("\x1b[2J\x1b[H");
+    }
 
     // for path in &changed {
     //     let path = path


### PR DESCRIPTION
1. Add a fallback for `cls` and `clear` both not found.
2. Fix panic for some rich-featured editor like jetbrains' saving file to a temp file like `main.rs~` first then moved to original file. 