### PR TITLE
Update doc to avoid misunderstanding

### DIFF
--- a/docs/src/configure.md
+++ b/docs/src/configure.md
@@ -25,7 +25,7 @@ We use `toml` to define some info for `dioxus` project.
    asset_dir = "public"
    ```
 
-### Application.Tool
+### Application.Tools
 
 You can combine different tools with `dioxus`.
 


### PR DESCRIPTION
change "Application.Tool" to "Application.Tools" to avoid user from typing "[application.tool]" in Dioxus.toml