### PR TITLE
fix(#60): handling default cfg & kebab_case name

### DIFF
--- a/src/cli/create/mod.rs
+++ b/src/cli/create/mod.rs
@@ -53,6 +53,7 @@ impl Create {
             .arg(&self.template)
             .arg("--name")
             .arg(&self.name)
+            .arg("--force")
             .stdout(Stdio::piped())
             .stderr(Stdio::inherit())
             .output()?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,7 +7,7 @@ async fn main() -> Result<()> {
     let args = Cli::parse();
     set_up_logging();
 
-    let dioxus_config = DioxusConfig::load()?;
+    let dioxus_config = DioxusConfig::load().unwrap_or(DioxusConfig::default());
 
     let plugin_state = PluginManager::init(dioxus_config.plugin);
 


### PR DESCRIPTION
closes #60

---

Notes:
1. While handing the default `DioxusConfig` in case of an err is done in main, an alternative is to introduce a `DioxusConfig::init()` function, so that `main()` remains pretty simple. I like this and I'd include this if you also agree.
1. The `--force` flag on `cargo generate` follows the `cargo-generate`'s flag based on which the project is not renamed.
    Thus, there is no error after that, as this CLI expects the user provided name to remain the same.