### PR TITLE
Move property so it is in the right category

### DIFF
--- a/src/assets/dioxus.toml
+++ b/src/assets/dioxus.toml
@@ -19,9 +19,9 @@ asset_dir = "public"
 # HTML title tag content
 title = "Dioxus | An elegant GUI library for Rust"
 
-index_on_404 = true
-
 [web.watcher]
+
+index_on_404 = true
 
 watch_path = ["src"]
 


### PR DESCRIPTION
index_on_404 was never used with the default config because the property is set on `web.watcher` and not on `web.app`