### PR TITLE
feat: enable and polish tool support for Binaryen and Tailwind CSS

### DIFF
--- a/docs/src/configure.md
+++ b/docs/src/configure.md
@@ -42,7 +42,7 @@ You can combine different tools with `dioxus`.
    tailwindcss = { input = "main.css", config = "tailwind.config.js" }
    ```
    You can set two optional keys :
-    - input: path of the input CSS file (default value is "public/tailwind.css")
+    - input: path of the input CSS file (default value is "public/input.css")
     - config: path to the config file for Tailwind (default value is "src/tailwind.config.js")
 
     When building on `release` profile, Dioxus will run `tailwindcss` with the `--minify` option.

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -49,7 +49,7 @@ pub fn build(config: &CrateConfig, quiet: bool) -> Result<BuildResult> {
     // [1] Build the .wasm module
     log::info!("🚅 Running build command...");
     let mut cmd = Command::new("cargo");
-    cmd.current_dir(&crate_dir)
+    cmd.current_dir(crate_dir)
         .arg("build")
         .arg("--target")
         .arg("wasm32-unknown-unknown")
@@ -98,12 +98,12 @@ pub fn build(config: &CrateConfig, quiet: bool) -> Result<BuildResult> {
 
     let input_path = match executable {
         ExecutableType::Binary(name) | ExecutableType::Lib(name) => target_dir
-            .join(format!("wasm32-unknown-unknown/{}", release_type))
-            .join(format!("{}.wasm", name)),
+            .join(format!("wasm32-unknown-unknown/{release_type}"))
+            .join(format!("{name}.wasm")),
 
         ExecutableType::Example(name) => target_dir
-            .join(format!("wasm32-unknown-unknown/{}/examples", release_type))
-            .join(format!("{}.wasm", name)),
+            .join(format!("wasm32-unknown-unknown/{release_type}/examples"))
+            .join(format!("{name}.wasm")),
     };
 
     let bindgen_result = panic::catch_unwind(move || {
@@ -154,16 +154,14 @@ pub fn build(config: &CrateConfig, quiet: bool) -> Result<BuildResult> {
                     }
                 }
             }
+        } else if !config.release {
+            log::warn!(
+                "This is a debug build - skipping Binaryen."
+            );
         } else {
-            if !config.release {
-                log::warn!(
-                    "This is a debug build - skipping Binaryen."
-                );
-            } else {
-                log::warn!(
-                    "Binaryen tool not found, you can use `dioxus tool add binaryen` to install it."
-                );
-            }
+            log::warn!(
+                "Binaryen tool not found, you can use `dioxus tool add binaryen` to install it."
+            );
         }
     }
 
@@ -193,7 +191,7 @@ pub fn build(config: &CrateConfig, quiet: bool) -> Result<BuildResult> {
                     config_path,
                 ];
 
-                if config.release == true {
+                if config.release {
                     args.push("--minify");
                 }
                 
@@ -216,7 +214,7 @@ pub fn build(config: &CrateConfig, quiet: bool) -> Result<BuildResult> {
         depth: 0,
     };
     if asset_dir.is_dir() {
-        for entry in std::fs::read_dir(&asset_dir)? {
+        for entry in std::fs::read_dir(asset_dir)? {
             let path = entry?.path();
             if path.is_file() {
                 std::fs::copy(&path, out_dir.join(path.file_name().unwrap()))?;

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -133,7 +133,7 @@ pub fn build(config: &CrateConfig, quiet: bool) -> Result<BuildResult> {
         let info = dioxus_tools.get("binaryen").unwrap();
         let binaryen = crate::tools::Tool::Binaryen;
 
-        if binaryen.is_installed() {
+        if binaryen.is_installed() && config.release {
             if let Some(sub) = info.as_table() {
                 if sub.contains_key("wasm_opt")
                     && sub.get("wasm_opt").unwrap().as_bool().unwrap_or(false)
@@ -144,22 +144,26 @@ pub fn build(config: &CrateConfig, quiet: bool) -> Result<BuildResult> {
                         .join("dioxus")
                         .join(format!("{}_bg.wasm", dioxus_config.application.name));
                     if target_file.is_file() {
-                        let mut args = vec![
+                        let args = vec![
                             target_file.to_str().unwrap(),
                             "-o",
                             target_file.to_str().unwrap(),
+                            "-Oz"
                         ];
-                        if config.release == true {
-                            args.push("-Oz");
-                        }
                         binaryen.call("wasm-opt", args)?;
                     }
                 }
             }
         } else {
-            log::warn!(
-                "Binaryen tool not found, you can use `dioxus tool add binaryen` to install it."
-            );
+            if !config.release {
+                log::warn!(
+                    "This is a debug build - skipping Binaryen."
+                );
+            } else {
+                log::warn!(
+                    "Binaryen tool not found, you can use `dioxus tool add binaryen` to install it."
+                );
+            }
         }
     }
 

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -174,7 +174,7 @@ pub fn build(config: &CrateConfig, quiet: bool) -> Result<BuildResult> {
 
                 let input_path = match sub.get("input") {
                     Some(val) => val.as_str().unwrap(),
-                    None => "./public",
+                    None => "./public/input.css",
                 };
                 let config_path = match sub.get("config") {
                     Some(val) => val.as_str().unwrap(),
@@ -192,7 +192,7 @@ pub fn build(config: &CrateConfig, quiet: bool) -> Result<BuildResult> {
                 if config.release == true {
                     args.push("--minify");
                 }
-
+                
                 tailwind.call("tailwindcss", args)?;
             }
         } else {

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -6,6 +6,7 @@ pub mod config;
 pub mod create;
 pub mod plugin;
 pub mod serve;
+pub mod tool;
 pub mod translate;
 pub mod version;
 
@@ -46,6 +47,10 @@ pub enum Commands {
     /// Translate some source file into Dioxus code.
     Translate(translate::Translate),
 
+    /// Install and/or configure tools - Tailwind, Binaryen, Sass
+    #[clap(subcommand)]
+    Tool(tool::Tool),
+
     /// Build, watch & serve the Rust WASM app and all of its assets.
     Serve(serve::Serve),
 
@@ -84,6 +89,7 @@ impl Commands {
             Commands::Plugin(_) => "plugin",
             Commands::Version(_) => "version",
             Commands::Autoformat(_) => "fmt",
+            Commands::Tool(_) => "tool",
         }
         .to_string()
     }

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -47,7 +47,7 @@ pub enum Commands {
     /// Translate some source file into Dioxus code.
     Translate(translate::Translate),
 
-    /// Install and/or configure tools - Tailwind, Binaryen, Sass
+    /// Install and/or configure tools.
     #[clap(subcommand)]
     Tool(tool::Tool),
 

--- a/src/cli/tool/mod.rs
+++ b/src/cli/tool/mod.rs
@@ -28,7 +28,7 @@ impl Tool {
             }
             Tool::AppPath {} => {
                 if let Some(v) = tools::tools_path().to_str() {
-                    println!("{}", v);
+                    println!("{v}");
                 } else {
                     return custom_error!("Tools path get failed.");
                 }

--- a/src/cli/tool/mod.rs
+++ b/src/cli/tool/mod.rs
@@ -2,7 +2,7 @@ use crate::tools;
 
 use super::*;
 
-/// Build the Rust WASM app and all of its assets.
+/// Install and/or configure tools - Tailwind, Binaryen
 #[derive(Clone, Debug, Deserialize, Subcommand)]
 #[clap(name = "tool")]
 pub enum Tool {

--- a/src/cli/translate/mod.rs
+++ b/src/cli/translate/mod.rs
@@ -1,8 +1,9 @@
 use std::process::exit;
 
-use dioxus_rsx::{BodyNode, CallBody, Component};
-use proc_macro2::{Ident, Span};
-use syn::punctuated::Punctuated;
+use dioxus_rsx::{BodyNode, CallBody};
+// use dioxus_rsx::Component;
+// use proc_macro2::{Ident, Span};
+// use syn::punctuated::Punctuated;
 
 use super::*;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -24,6 +24,11 @@ async fn main() -> anyhow::Result<()> {
             .translate()
             .map_err(|e| anyhow!("🚫 Translation of HTML into RSX failed: {}", e)),
 
+        Tool(opts) => opts
+            .tool()
+            .await
+            .map_err(|e| anyhow!("🚫 Configuring tools failed: {}", e)),
+
         Build(opts) => opts
             .build()
             .map_err(|e| anyhow!("🚫 Building project failed: {}", e)),

--- a/src/tools.rs
+++ b/src/tools.rs
@@ -133,7 +133,7 @@ impl Tool {
         match self {
             Self::Binaryen => "version_105",
             Self::Sass => "1.51.0",
-            Self::Tailwind => "v3.1.6",
+            Self::Tailwind => "latest",
         }
     }
 
@@ -161,7 +161,7 @@ impl Tool {
                     _ => "",
                 };
                 format!(
-                    "https://github.com/tailwindlabs/tailwindcss/releases/download/{version}/tailwindcss-{target}-x64{optional_ext}",
+                    "https://github.com/tailwindlabs/tailwindcss/releases/{version}/download/tailwindcss-{target}-x64{optional_ext}",
                     version = self.tool_version(),
                     target = self.target_platform(),
                     optional_ext = windows_extension

--- a/src/tools.rs
+++ b/src/tools.rs
@@ -18,9 +18,9 @@ pub enum Tool {
     Tailwind,
 }
 
-// pub fn tool_list() -> Vec<&'static str> {
-//     vec!["binaryen", "sass", "tailwindcss"]
-// }
+pub fn tool_list() -> Vec<&'static str> {
+    vec!["binaryen", "sass", "tailwindcss"]
+}
 
 pub fn app_path() -> PathBuf {
     let data_local = dirs::data_local_dir().unwrap();
@@ -237,7 +237,7 @@ impl Tool {
             std::fs::rename(tool_path.join(dir_name), tool_path.join(self.name()))?;
         } else if self.extension() == "bin" {
             let bin_path = match self.target_platform() {
-                "windows" => tool_path.join(&dir_name).join(self.name()).join(".exe"),
+                "windows" => tool_path.join(&dir_name).join(String::from(self.name()) + ".exe"),
                 _ => tool_path.join(&dir_name).join(self.name()),
             };
             // Manualy creating tool directory because we directly download the binary via Github

--- a/src/tools.rs
+++ b/src/tools.rs
@@ -277,21 +277,21 @@ impl Tool {
         let command_file = match self {
             Tool::Binaryen => {
                 if cfg!(target_os = "windows") {
-                    format!("{}.exe", command)
+                    format!("{command}.exe")
                 } else {
                     command.to_string()
                 }
             }
             Tool::Sass => {
                 if cfg!(target_os = "windows") {
-                    format!("{}.bat", command)
+                    format!("{command}.bat")
                 } else {
                     command.to_string()
                 }
             }
             Tool::Tailwind => {
                 if cfg!(target_os = "windows") {
-                    format!("{}.exe", command)
+                    format!("{command}.exe")
                 } else {
                     command.to_string()
                 }
@@ -314,11 +314,11 @@ impl Tool {
 }
 
 pub fn extract_zip(file: &Path, target: &Path) -> anyhow::Result<()> {
-    let zip_file = std::fs::File::open(&file)?;
+    let zip_file = std::fs::File::open(file)?;
     let mut zip = zip::ZipArchive::new(zip_file)?;
 
     if !target.exists() {
-        let _ = std::fs::create_dir_all(target)?;
+        std::fs::create_dir_all(target)?;
     }
 
     for i in 0..zip.len() {
@@ -326,7 +326,7 @@ pub fn extract_zip(file: &Path, target: &Path) -> anyhow::Result<()> {
         if file.is_dir() {
             // dir
             let target = target.join(Path::new(&file.name().replace('\\', "")));
-            let _ = std::fs::create_dir_all(target)?;
+            std::fs::create_dir_all(target)?;
         } else {
             // file
             let file_path = target.join(Path::new(file.name()));

--- a/src/tools.rs
+++ b/src/tools.rs
@@ -19,7 +19,7 @@ pub enum Tool {
 }
 
 pub fn tool_list() -> Vec<&'static str> {
-    vec!["binaryen", "sass", "tailwindcss"]
+    vec!["binaryen", "tailwindcss"]
 }
 
 pub fn app_path() -> PathBuf {


### PR DESCRIPTION
This fixes #96.

Changes:
- Enabled `dioxus tool` subcommand.
- `dioxus tool add tailwindcss` now downloads latest available Tailwind CSS version from GitHub.
- wasm-opt now executes only on release builds (previously, it executed but did nothing on debug builds)
- Changed default path for Tailwind input from "public/tailwind.css" to "public/input.css" (the former would cause issues during build, as both the input and the output have the same name)