### PR TITLE
fix: rebuild hangs on windows

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -718,6 +718,7 @@ dependencies = [
  "rsx-rosetta",
  "serde",
  "serde_json",
+ "subprocess",
  "syn",
  "tar",
  "thiserror",
@@ -2572,6 +2573,16 @@ name = "strsim"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
+
+[[package]]
+name = "subprocess"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c2e86926081dda636c546d8c5e641661049d7562a68f5488be4a1f7f66f6086"
+dependencies = [
+ "libc",
+ "winapi",
+]
 
 [[package]]
 name = "subtle"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,7 @@ chrono = "0.4.19"
 anyhow = "1.0.53"
 hyper = "0.14.17"
 indicatif = "0.17.0-rc.11"
+subprocess = "0.2.9"
 
 axum = { version = "0.5.1", features = ["ws", "headers"] }
 tower-http = { version = "0.2.2", features = ["fs", "trace"] }


### PR DESCRIPTION
When I edit the source code when dioxus serve on Windows, it freezes with the following display.

```
[INFO] 🪁 Rebuild project
[INFO] 🚅 Running build command...
| 💼 Waiting to start build the project...        
```

This problem occurs when the source code is edited in IntelliJ IDEA and VSCode.
For some reason it does not happen when editing with notepad. (Probably because notepad does not run Cargo.)

The problem seems to be related to the handling of stdout, stderr of the subprocess.
I could not modify it to work with the standard library, so I used subprocess crate and it works.