### PR TITLE
Make error more illuminating

### DIFF
--- a/src/cargo.rs
+++ b/src/cargo.rs
@@ -34,7 +34,7 @@ pub fn crate_root() -> Result<PathBuf> {
             }
             None
         })
-        .ok_or_else(|| Error::CargoError("Failed to find the cargo directory".to_string()))
+        .ok_or_else(|| Error::CargoError("Failed to find directory containing Cargo.toml".to_string()))
 }
 
 /// Checks if the directory contains `Cargo.toml`


### PR DESCRIPTION
I was wondering what the previous error message ment. So I had to look it up.

Cargo directory might just mean ~/.cargo