### PR TITLE
Build with --features cli argument

### DIFF
--- a/src/cli/build/mod.rs
+++ b/src/cli/build/mod.rs
@@ -26,6 +26,10 @@ impl Build {
             crate_config.set_profile(self.build.profile.unwrap());
         }
 
+        if self.build.features.is_some() {
+            crate_config.set_features(self.build.features.unwrap());
+        }
+
         let platform = self.build.platform.unwrap_or_else(|| {
             crate_config
                 .dioxus_config


### PR DESCRIPTION
Update the build config to read any provided --features flags.

Without this, it does not seem possible to combine SSR + Web platforms while also using dioxus-router.
----
Due to weak dependency on the "web" feature from dioxus-router crate - I need the ability to conditional turn on dioxus-router/web while building the Web platform.
