### PR TITLE
Fix formatting issue with VSCode extension

### DIFF
--- a/extension/package.json
+++ b/extension/package.json
@@ -42,7 +42,33 @@
                 "command": "extension.formatRsxDocument",
                 "title": "Dioxus: Format RSX Document"
             }
-        ]
+        ],
+        "configuration": {
+            "properties": {
+                "dioxus.formatOnSave": {
+                    "type": [
+                        "string"
+                    ],
+                    "default": "followFormatOnSave",
+                    "enum": [
+                        "followFormatOnSave",
+                        "enabled",
+                        "disabled"
+                    ],
+                    "enumItemLabels": [
+                        "Follow the normal formatOnSave config",
+                        "Enabled",
+                        "Disabled"
+                    ],
+                    "enumDescriptions": [
+                        "Only format Rsx when saving files if the editor.formatOnSave config is enabled",
+                        "Always format Rsx when a Rust file is saved",
+                        "Never format Rsx when a file is saved"
+                    ],
+                    "description": "Format RSX when a file is saved."
+                }
+            }
+        }
     },
     "scripts": {
         "vscode:prepublish": "npm run build-base -- --minify",

--- a/extension/src/main.ts
+++ b/extension/src/main.ts
@@ -117,11 +117,16 @@ function fmtSelection() {
 
 function fmtDocumentOnSave(e: vscode.TextDocumentWillSaveEvent) {
 	// check the settings to make sure format on save is configured
-	if (!vscode.workspace.getConfiguration('editor', e.document).get('formatOnSave')) {
-		return;
+	const dioxusConfig = vscode.workspace.getConfiguration('dioxus', e.document).get('formatOnSave');
+	const globalConfig = vscode.workspace.getConfiguration('editor', e.document).get('formatOnSave');
+	if (
+		(dioxusConfig === 'enabled') ||
+		(dioxusConfig !== 'disabled' && globalConfig)
+	) {
+		fmtDocument(e.document);
 	}
-	fmtDocument(e.document);
 }
+
 function fmtDocument(document: vscode.TextDocument) {
 	try {
 		if (document.languageId !== "rust" || document.uri.scheme !== "file") {

--- a/extension/tsconfig.json
+++ b/extension/tsconfig.json
@@ -1,8 +1,8 @@
 {
 	"compilerOptions": {
 		"module": "commonjs",
-		"target": "es2019",
-		"lib": ["ES2019"],
+		"target": "es2021",
+		"lib": ["ES2021"],
 		"outDir": "out",
 		"sourceMap": true,
 		"strict": true,


### PR DESCRIPTION
The VSCode extension had a couple of issues that this PR should fix:

- The Dioxus CLI [logs warnings](https://github.com/DioxusLabs/cli/blob/d5bda3c7537e27879866f0e0989988d945f02e9d/src/main.rs#L15) [to stdout](https://github.com/DioxusLabs/cli/blob/d5bda3c7537e27879866f0e0989988d945f02e9d/src/logging.rs#L32) if it can't find a configuration file. The extension expects a JSON response so its fails to parse the format info.
- The app created by `dioxus create hello` looks something like:
```rust
fn app(cx: Scope) -> Element {
    cx.render(rsx! (
        div { style: "text-align: center;",
            h1 { "🌗 Dioxus 🚀" }
            h3 { "Frontend that scales." }
            p {
                "Dioxus is a portable, performant, and ergonomic framework for building cross-platform user interfaces in Rust."
            }
        }
    ))
}
```
The emoji in the "rsx" macro prevent the formatting from working correctly. Specifically it deletes two characters too much, removing the trailing `))` parenthesis.

To fix these issues I made the following changes to the VSCode extension:
- Set the current directory for the spawned Dioxus CLI.
- Assume the last non-empty line of stdout is the JSON response.
- Convert from utf8 to utf16 positions.

I also made some other changes:
- Check so that the source file hasn't changed in the formatted range before applying an edit.
- Notify the user for more error conditions, so that its obvious that the command failed.
  - Otherwise the user might be confused and think the command was just never triggered.
- Check for the `editor.formatOnSave` before formatting on save.
  - Also added an extension specific config called `dioxus.formatOnSave` to allow not formatting Rsx while still formatting Rust code on save.

It would probably be a good idea to change the Dioxus CLI to not write logging when some special flag is passed or maybe to log with JSON output.