### PR TITLE
feat: add "--open" option to `dioxus serve`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -722,6 +722,7 @@ dependencies = [
  "log",
  "mlua",
  "notify",
+ "open",
  "proc-macro2",
  "regex",
  "reqwest",
@@ -1522,6 +1523,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "30e22bd8629359895450b59ea7a776c850561b96a3b1d31321c1949d9e6c9146"
 
 [[package]]
+name = "is-docker"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "928bae27f42bc99b60d9ac7334e3a21d10ad8f1835a4e12ec3ec0464765ed1b3"
+dependencies = [
+ "once_cell",
+]
+
+[[package]]
+name = "is-wsl"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "173609498df190136aa7dea1a91db051746d339e18476eed5ca40521f02d7aa5"
+dependencies = [
+ "is-docker",
+ "once_cell",
+]
+
+[[package]]
 name = "is_executable"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1899,6 +1919,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
+name = "open"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d16814a067484415fda653868c9be0ac5f2abd2ef5d951082a5f2fe1b3662944"
+dependencies = [
+ "is-wsl",
+ "pathdiff",
+]
+
+[[package]]
 name = "openssl"
 version = "0.10.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1991,6 +2021,12 @@ dependencies = [
  "rand_core",
  "subtle",
 ]
+
+[[package]]
+name = "pathdiff"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8835116a5c179084a830efb3adc117ab007512b535bc1a21c991d3b32a6b44dd"
 
 [[package]]
 name = "pbkdf2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -82,6 +82,7 @@ dioxus-html = { version = "0.3", features = ["hot-reload-context"] }
 dioxus-core = { version = "0.3", features = ["serialize"] }
 dioxus-autofmt = "0.3.0"
 rsx-rosetta = { version = "0.3" }
+open = "4.1.0"
 
 [[bin]]
 path = "src/main.rs"

--- a/docs/src/cmd/serve.md
+++ b/docs/src/cmd/serve.md
@@ -47,3 +47,11 @@ You can use `--example {name}` to start a example code.
 # build `example/test` code
 dioxus serve --exmaple test
 ```
+
+## Open Browser
+
+You can add `--open` flag to open system default browser when server startup.
+
+```
+dioxus serve --open
+```

--- a/src/cli/cfg.rs
+++ b/src/cli/cfg.rs
@@ -45,6 +45,11 @@ pub struct ConfigOptsServe {
     #[clap(default_value_t = 8080)]
     pub port: u16,
 
+    /// Open the app in the default browser [default: false]
+    #[clap(long)]
+    #[serde(default)]
+    pub open: bool,
+
     /// Build a example [default: ""]
     #[clap(long)]
     pub example: Option<String>,

--- a/src/cli/serve/mod.rs
+++ b/src/cli/serve/mod.rs
@@ -68,7 +68,7 @@ impl Serve {
         Serve::regen_dev_page(&crate_config)?;
 
         // start the develop server
-        server::startup(self.serve.port, crate_config.clone()).await?;
+        server::startup(self.serve.port, crate_config.clone(), self.serve.open).await?;
 
         Ok(())
     }


### PR DESCRIPTION
This PR adds the "--open" CLI parameter to the "serve" option, allowing the CLI to open the app in the user's default browser.

`dioxus serve --open` will open the app in the default browser.
`dioxus serve --open --hot-reload` will do the same, but with hot-reloading active.

This is just a nice-to-have feature that Trunk has and that I kind of miss since switching to Dioxus CLI.

This may introduce a bug in certain systems where the browser starts too early and times out as the server hasn't finished starting, meaning the user will have to manually refresh once the server starts. 

A fix would involve starting the server, then probing the URL to see what response it returns before actually opening the browser (but that would require spawning a separate process/thread and adding too much complexity IMO, but let me know if you want me to add this.)