### PR TITLE
add shared array buffer support for dev server as optional config

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -789,14 +789,14 @@ dependencies = [
  "tower-http 0.2.5",
  "walkdir",
  "wasm-bindgen-cli-support",
- "zip 0.6.4",
+ "zip 0.6.5",
 ]
 
 [[package]]
 name = "dioxus-core"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc602f0ca7030f80fe4abc47cc43ffa75c6e7f48208c2b3f6ae24ec7bc6f6618"
+checksum = "4e4d15b0bb9c58d015b2295f240600dd76e427758377569fa33783afc295706a"
 dependencies = [
  "bumpalo",
  "bumpslab",
@@ -1608,15 +1608,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "iri-string"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f0f7638c1e223529f1bfdc48c8b133b9e0b434094d1d28473161ee48b235f78"
-dependencies = [
- "nom",
-]
-
-[[package]]
 name = "is_executable"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1703,9 +1694,9 @@ checksum = "884e2677b40cc8c339eaefcb701c32ef1fd2493d71118dc0ca4b6a736c93bd67"
 
 [[package]]
 name = "libc"
-version = "0.2.142"
+version = "0.2.143"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a987beff54b60ffa6d51982e1aa1146bc42f19bd26be28b0586f252fccf5317"
+checksum = "edc207893e85c5d6be840e969b496b53d94cec8be2d501b214f50daa97fa8024"
 
 [[package]]
 name = "libz-sys"
@@ -2632,9 +2623,9 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.160"
+version = "1.0.162"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb2f3770c8bce3bcda7e149193a069a0f4365bda1fa5cd88e03bca26afc1216c"
+checksum = "71b2f6e1ab5c2b98c05f0f35b236b22e8df7ead6ffbf51d7808da7f8817e7ab6"
 dependencies = [
  "serde_derive",
 ]
@@ -2651,9 +2642,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.160"
+version = "1.0.162"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "291a097c63d8497e00160b166a967a4a79c64f3facdd01cbd7502231688d77df"
+checksum = "a2a0814352fd64b58489904a44ea8d90cb1a91dcb6b4f5ebabc32c8318e93cb6"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2919,9 +2910,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.20"
+version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd0cbfecb4d19b5ea75bb31ad904eb5b9fa13f21079c3b92017ebdf4999a5890"
+checksum = "8f3403384eaacbca9923fa06940178ac13e4edb725486d70e8e15881d0c836cc"
 dependencies = [
  "serde",
  "time-core",
@@ -2929,9 +2920,9 @@ dependencies = [
 
 [[package]]
 name = "time-core"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e153e1f1acaef8acc537e68b44906d2db6436e2b35ac2c6b42640fff91f00fd"
+checksum = "7300fbefb4dadc1af235a9cef3737cea692a9d97e1b9cbcd4ebdae6f8868e6fb"
 
 [[package]]
 name = "tinyvec"
@@ -3870,9 +3861,9 @@ dependencies = [
 
 [[package]]
 name = "zip"
-version = "0.6.4"
+version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0445d0fbc924bb93539b4316c11afb121ea39296f99a3c4c9edad09e3658cdef"
+checksum = "7e92305c174683d78035cbf1b70e18db6329cc0f1b9cae0a52ca90bf5bfe7125"
 dependencies = [
  "aes",
  "byteorder",
@@ -3884,7 +3875,7 @@ dependencies = [
  "hmac",
  "pbkdf2",
  "sha1",
- "time 0.3.20",
+ "time 0.3.21",
  "zstd",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -50,6 +50,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "alloc-no-stdlib"
+version = "2.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc7bb162ec39d46ab1ca8c77bf72e890535becd1751bb45f64c597edb4c8c6b3"
+
+[[package]]
+name = "alloc-stdlib"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94fb8275041c72129eb51b7d0322c29b8387a0386127718b096429201a5d6ece"
+dependencies = [
+ "alloc-no-stdlib",
+]
+
+[[package]]
 name = "android_system_properties"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -75,6 +90,20 @@ name = "arrayvec"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
+
+[[package]]
+name = "async-compression"
+version = "0.3.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "942c7cd7ae39e91bde4820d74132e9862e62c2f386c3aa90ccf55949f5bad63a"
+dependencies = [
+ "brotli",
+ "flate2",
+ "futures-core",
+ "memchr",
+ "pin-project-lite",
+ "tokio",
+]
 
 [[package]]
 name = "async-trait"
@@ -239,6 +268,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cce20737498f97b993470a6e536b8523f0af7892a4f928cceb1ac5e52ebe7e"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "brotli"
+version = "3.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1a0b1dbcc8ae29329621f8d4f0d835787c1c38bb1401979b49d13b0b305ff68"
+dependencies = [
+ "alloc-no-stdlib",
+ "alloc-stdlib",
+ "brotli-decompressor",
+]
+
+[[package]]
+name = "brotli-decompressor"
+version = "2.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b6561fd3f895a11e8f72af2cb7d22e08366bebc2b6b57f7744c4bda27034744"
+dependencies = [
+ "alloc-no-stdlib",
+ "alloc-stdlib",
 ]
 
 [[package]]
@@ -1522,6 +1572,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "30e22bd8629359895450b59ea7a776c850561b96a3b1d31321c1949d9e6c9146"
 
 [[package]]
+name = "iri-string"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f0f7638c1e223529f1bfdc48c8b133b9e0b434094d1d28473161ee48b235f78"
+dependencies = [
+ "nom",
+]
+
+[[package]]
 name = "is_executable"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1738,6 +1797,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
 name = "miniz_oxide"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1821,6 +1886,16 @@ dependencies = [
  "cfg-if",
  "libc",
  "static_assertions",
+]
+
+[[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
 ]
 
 [[package]]
@@ -2902,6 +2977,8 @@ version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aba3f3efabf7fb41fae8534fc20a817013dd1c12cb45441efb6c82e6556b4cd8"
 dependencies = [
+ "async-compression",
+ "base64 0.13.1",
  "bitflags",
  "bytes",
  "futures-core",
@@ -2910,12 +2987,14 @@ dependencies = [
  "http-body",
  "http-range-header",
  "httpdate",
+ "iri-string",
  "mime",
  "mime_guess",
  "percent-encoding",
  "pin-project-lite",
  "tokio",
  "tokio-util",
+ "tower",
  "tower-layer",
  "tower-service",
  "tracing",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,7 @@ indicatif = "0.17.0-rc.11"
 subprocess = "0.2.9"
 
 axum = { version = "0.5.1", features = ["ws", "headers"] }
-tower-http = { version = "0.2.2", features = ["fs", "trace"] }
+tower-http = { version = "0.2.2", features = ["full"] }
 headers = "0.3.7"
 
 walkdir = "2"

--- a/docs/src/cmd/serve.md
+++ b/docs/src/cmd/serve.md
@@ -55,3 +55,17 @@ You can add `--open` flag to open system default browser when server startup.
 ```
 dioxus serve --open
 ```
+
+
+## Cross Origin Policy
+
+use `cross-origin-policy` can change corss-origin header in serverside.
+
+```
+  Cross-Origin-Opener-Policy: same-origin
+  Cross-Origin-Embedder-Policy: require-corp
+```
+
+```
+dioxus serve --corss-origin-policy
+```

--- a/src/cli/cfg.rs
+++ b/src/cli/cfg.rs
@@ -77,10 +77,11 @@ pub struct ConfigOptsServe {
     #[serde(default)]
     pub hot_reload: bool,
 
-    /// Build with shared_array_buffer enabled in JS [default: false]
+    /// Set cross-origin-policy to same-origin [default: false]
+    #[clap(name="cross-origin-policy")]
     #[clap(long)]
     #[serde(default)]
-    pub shared_array_buffer: bool,
+    pub cross_origin_policy: bool,
 
     /// Space separated list of features to activate
     #[clap(long)]

--- a/src/cli/cfg.rs
+++ b/src/cli/cfg.rs
@@ -72,6 +72,11 @@ pub struct ConfigOptsServe {
     #[serde(default)]
     pub hot_reload: bool,
 
+    /// Build with shared_array_buffer enabled in JS [default: false]
+    #[clap(long)]
+    #[serde(default)]
+    pub shared_array_buffer: bool,
+
     /// Space separated list of features to activate
     #[clap(long)]
     pub features: Option<Vec<String>>,

--- a/src/cli/serve/mod.rs
+++ b/src/cli/serve/mod.rs
@@ -20,6 +20,7 @@ impl Serve {
 
         // change the relase state.
         crate_config.with_hot_reload(self.serve.hot_reload);
+        crate_config.with_shared_array_buffer(self.serve.shared_array_buffer);
         crate_config.with_release(self.serve.release);
         crate_config.with_verbose(self.serve.verbose);
 

--- a/src/cli/serve/mod.rs
+++ b/src/cli/serve/mod.rs
@@ -20,7 +20,7 @@ impl Serve {
 
         // change the relase state.
         crate_config.with_hot_reload(self.serve.hot_reload);
-        crate_config.with_shared_array_buffer(self.serve.shared_array_buffer);
+        crate_config.with_cross_origin_policy(self.serve.cross_origin_policy);
         crate_config.with_release(self.serve.release);
         crate_config.with_verbose(self.serve.verbose);
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -146,6 +146,7 @@ pub struct CrateConfig {
     pub dioxus_config: DioxusConfig,
     pub release: bool,
     pub hot_reload: bool,
+    pub shared_array_buffer: bool,
     pub verbose: bool,
     pub custom_profile: Option<String>,
     pub features: Option<Vec<String>>,
@@ -213,6 +214,7 @@ impl CrateConfig {
             release,
             dioxus_config,
             hot_reload,
+            shared_array_buffer: false,
             custom_profile,
             features,
             verbose,
@@ -231,6 +233,11 @@ impl CrateConfig {
 
     pub fn with_hot_reload(&mut self, hot_reload: bool) -> &mut Self {
         self.hot_reload = hot_reload;
+        self
+    }
+
+    pub fn with_shared_array_buffer(&mut self, shared_array_buffer: bool) -> &mut Self {
+        self.shared_array_buffer = shared_array_buffer;
         self
     }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -146,7 +146,7 @@ pub struct CrateConfig {
     pub dioxus_config: DioxusConfig,
     pub release: bool,
     pub hot_reload: bool,
-    pub shared_array_buffer: bool,
+    pub cross_origin_policy: bool,
     pub verbose: bool,
     pub custom_profile: Option<String>,
     pub features: Option<Vec<String>>,
@@ -214,7 +214,7 @@ impl CrateConfig {
             release,
             dioxus_config,
             hot_reload,
-            shared_array_buffer: false,
+            cross_origin_policy: false,
             custom_profile,
             features,
             verbose,
@@ -236,8 +236,8 @@ impl CrateConfig {
         self
     }
 
-    pub fn with_shared_array_buffer(&mut self, shared_array_buffer: bool) -> &mut Self {
-        self.shared_array_buffer = shared_array_buffer;
+    pub fn  with_cross_origin_policy(&mut self, cross_origin_policy: bool) -> &mut Self {
+        self.cross_origin_policy = cross_origin_policy;
         self
     }
 

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -176,13 +176,6 @@ pub async fn startup_hot_reload(ip: String, port: u16, config: CrateConfig, star
         .clone()
         .unwrap_or_else(|| vec![PathBuf::from("src")]);
 
-    let cors = CorsLayer::new()
-        // allow `GET` and `POST` when accessing the resource
-        .allow_methods([Method::GET, Method::POST])
-        // allow requests from any origin
-        .allow_origin(Any)
-        .allow_headers(Any);
-
     let watcher_config = config.clone();
     let watcher_ip = ip.clone();
     let mut last_update_time = chrono::Local::now().timestamp();
@@ -285,7 +278,7 @@ pub async fn startup_hot_reload(ip: String, port: u16, config: CrateConfig, star
     .allow_origin(Any)
     .allow_headers(Any);
 
-    let (coep, coop) = if config.shared_array_buffer {
+    let (coep, coop) = if config.cross_origin_policy {
         (
             HeaderValue::from_static("require-corp"),
             HeaderValue::from_static("same-origin"),
@@ -399,13 +392,6 @@ pub async fn startup_default(
 
     let mut last_update_time = chrono::Local::now().timestamp();
 
-    let cors = CorsLayer::new()
-        // allow `GET` and `POST` when accessing the resource
-        .allow_methods([Method::GET, Method::POST])
-        // allow requests from any origin
-        .allow_origin(Any)
-        .allow_headers(Any);
-
     // file watcher: check file change
     let allow_watch_path = config
         .dioxus_config
@@ -476,7 +462,7 @@ pub async fn startup_default(
     .allow_origin(Any)
     .allow_headers(Any);
 
-    let (coep, coop) = if config.shared_array_buffer {
+    let (coep, coop) = if config.cross_origin_policy {
         (
             HeaderValue::from_static("require-corp"),
             HeaderValue::from_static("same-origin"),


### PR DESCRIPTION
Already tested.

If this option is not enabled, `serve` should behave exactly the same as current implementation.

```
 ~  dioxus serve --help                                
dioxus-serve 
Build, watch & serve the Rust WASM app and all of its assets

USAGE:
    dioxus serve [OPTIONS] [TARGET]

ARGS:
    <TARGET>    The index HTML file to drive the bundling process [default: index.html]

OPTIONS:
        --example <EXAMPLE>      Build a example [default: ""]
        --features <FEATURES>    Space separated list of features to activate
    -h, --help                   Print help information
        --hot-reload             Build with hot reloading rsx [default: false]
        --platform <PLATFORM>    Build platform: support Web & Desktop [default: "default_platform"]
        --port <PORT>            Port of dev server [default: 8080]
        --profile <PROFILE>      Build with custom profile
        --release                Build in release mode [default: false]
        --shared-array-buffer    Build with shared_array_buffer enabled in JS [default: false]
        --verbose    
```