### PR TITLE
Fix wasm-bindgen version mismatch

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ license = "MIT/Apache-2.0"
 # cli core
 clap = { version = "3.0.14", features = ["derive"] }
 thiserror = "1.0.30"
-wasm-bindgen-cli-support = "0.2.83"
+wasm-bindgen-cli-support = "0.2"
 colored = "2.0.0"
 
 # features


### PR DESCRIPTION
Removes the minor (0.0.x) version number from being used so that the CLI always uses the latest non-breaking change release of wasm-bindgen.