### PR TITLE
Ignore base_path changes for serve

### DIFF
--- a/src/cli/serve/mod.rs
+++ b/src/cli/serve/mod.rs
@@ -36,6 +36,9 @@ impl Serve {
             crate_config.set_features(self.serve.features.unwrap());
         }
 
+        // Subdirectories don't work with the server
+        crate_config.dioxus_config.web.app.base_path = None;
+
         let platform = self.serve.platform.unwrap_or_else(|| {
             crate_config
                 .dioxus_config


### PR DESCRIPTION
The dioxus serve tool does not host the assets on the right subdirectory when using base_path. I tried fixing the axum code, but I don't know how to move the fileserver into it's own subpath.

I think ignoring the base_path is a good workaround for now.