### PR TITLE
Fix formatting a single file with --file flag

### DIFF
--- a/extension/src/main.ts
+++ b/extension/src/main.ts
@@ -136,28 +136,26 @@ function fmtDocument(document: vscode.TextDocument) {
 		const [editor,] = vscode.window.visibleTextEditors.filter(editor => editor.document.fileName === document.fileName);
 		if (!editor) return; // Need an editor to apply text edits.
 
-		const text = document.getText();
 		const fileDir = document.fileName.slice(0, document.fileName.lastIndexOf('\\'));
-
-		const child_proc = spawn(serverPath, ["fmt", "--file", text], {
+		const child_proc = spawn(serverPath, ["fmt", "--file", document.fileName], {
 			cwd: fileDir ? fileDir : undefined,
 		});
 
 		let result = '';
 		child_proc.stdout?.on('data', data => result += data);
 
-		type RsxEdit = {
+		/*type RsxEdit = {
 			formatted: string,
 			start: number,
 			end: number
-		}
+		}*/
 
 		child_proc.on('close', () => {
 			if (child_proc.exitCode !== 0) {
 				vscode.window.showWarningMessage(`Errors occurred while formatting. Make sure you have the most recent Dioxus-CLI installed!\nDioxus-CLI exited with exit code ${child_proc.exitCode}\n\nData from Dioxus-CLI:\n${result}`);
 				return;
 			}
-			if (result.length === 0) return;
+			/*if (result.length === 0) return;
 
 			// Used for error message:
 			const originalResult = result;
@@ -245,9 +243,10 @@ function fmtDocument(document: vscode.TextDocument) {
 					undoStopAfter: false,
 					undoStopBefore: false
 				});
+		
 			} catch (err) {
 				vscode.window.showWarningMessage(`Errors occurred while formatting. Make sure you have the most recent Dioxus-CLI installed!\n${err}\n\nData from Dioxus-CLI:\n${originalResult}`);
-			}
+			}*/
 		});
 
 		child_proc.on('error', (err) => {
@@ -257,6 +256,7 @@ function fmtDocument(document: vscode.TextDocument) {
 		vscode.window.showWarningMessage(`Errors occurred while formatting. Make sure you have the most recent Dioxus-CLI installed! \n${error}`);
 	}
 }
+
 
 
 // I'm using the approach defined in rust-analyzer here

--- a/src/cli/autoformat/mod.rs
+++ b/src/cli/autoformat/mod.rs
@@ -1,5 +1,5 @@
 use futures::{stream::FuturesUnordered, StreamExt};
-use std::process::exit;
+use std::{process::exit, fs};
 
 use super::*;
 
@@ -44,10 +44,28 @@ impl Autoformat {
             }
         }
 
+        // Format single file
         if let Some(file) = self.file {
-            let edits = dioxus_autofmt::fmt_file(&file);
-            let as_json = serde_json::to_string(&edits).unwrap();
-            println!("{}", as_json);
+            let file_content = fs::read_to_string(&file);
+
+            match file_content {
+                Ok(s) => {
+                    let edits = dioxus_autofmt::fmt_file(&s);
+                    let out = dioxus_autofmt::apply_formats(&s, edits);
+                    match fs::write(&file, out) {
+                        Ok(_) => {
+                            println!("formatted {}", file);
+                        }
+                        Err(e) => {
+                            println!("failed to write formatted content to file: {}", e);
+                        }
+                    }
+                },
+                Err(e) => {
+                    eprintln!("failed to open file: {}", e);
+                    exit(1);
+                }
+            }
         }
 
         Ok(())

--- a/src/cli/autoformat/mod.rs
+++ b/src/cli/autoformat/mod.rs
@@ -57,7 +57,7 @@ impl Autoformat {
                             println!("formatted {}", file);
                         }
                         Err(e) => {
-                            println!("failed to write formatted content to file: {}", e);
+                            eprintln!("failed to write formatted content to file: {}", e);
                         }
                     }
                 }

--- a/src/cli/autoformat/mod.rs
+++ b/src/cli/autoformat/mod.rs
@@ -1,5 +1,5 @@
 use futures::{stream::FuturesUnordered, StreamExt};
-use std::{process::exit, fs};
+use std::{fs, process::exit};
 
 use super::*;
 
@@ -60,7 +60,7 @@ impl Autoformat {
                             println!("failed to write formatted content to file: {}", e);
                         }
                     }
-                },
+                }
                 Err(e) => {
                     eprintln!("failed to open file: {}", e);
                     exit(1);


### PR DESCRIPTION
CLI was passing the String after the --file flag to the autofmt crate when it expected the file's contents.

Closes DioxusLabs/Dioxus#1042